### PR TITLE
Update autocomplete.css

### DIFF
--- a/autocomplete.css
+++ b/autocomplete.css
@@ -6,12 +6,16 @@
        max-height: 310px !important;
     }
 
-    .ac-type-icon, .ac-site-icon {
+    .ac-type-icon, .ac-site-icon:not([type="insecureWarning"]) {            /* for all awesomebar suggestions icons (except those for contextual feedback on insecure passwords) */
         margin-top: 6px;
     }
 
-    .ac-title, .ac-separator, .ac-url, .ac-action {
-        font-size: 12px !important;
+    .ac-site-icon[type="insecureWarning"], .ac-site-icon[type="login"] {    /* for the icons in contextual feedback on insecure passwords */
+        margin-top: 0;
+    }
+
+    /*.ac-title,*/ .ac-separator, .ac-url, .ac-action {
+        font-size: 14px !important;
     }
 
     .autocomplete-richlistitem[collapsed="true"] {
@@ -83,4 +87,10 @@
     .autocomplete-richlistitem[actiontype="visiturl"] .ac-url {
         margin-bottom: 0;
     }
+
+    .autocomplete-richlistitem[type="favicon"] .ac-url-text,
+    .autocomplete-richlistitem[type="bookmark"] .ac-url-text{
+        max-width: none !important;                     /* or initial*/
+    }
+
 }


### PR DESCRIPTION
- the `font-size` of the URLs of the suggestions to become 14px - from 12px -
- the styling of `.ac-site-icon` not to apply to icons in contextual feedback on insecure passwords (introduced in FF52)
- fix the truncation that occured to (long) URLs of the displayed suggestions.