### PR TITLE
Update autocomplete.css

### DIFF
--- a/autocomplete.css
+++ b/autocomplete.css
@@ -2,7 +2,6 @@
 
 @-moz-document url(chrome://browser/content/browser.xul) {
     richlistbox.autocomplete-richlistbox {
-       height: auto !important;
        max-height: 310px !important;
     }
 


### PR DESCRIPTION
That rule makes the last 3 entries in the dropdown suggestions hidden (or half-hidden if it's only 1 entry) in FF57.